### PR TITLE
Home page adjustments (CLI -> Obsidian plugin)

### DIFF
--- a/components/CloudPublishSteps.tsx
+++ b/components/CloudPublishSteps.tsx
@@ -5,59 +5,88 @@ export default function CloudPublishSteps() {
         <div className="py-10 sm:px-2 lg:relative lg:px-0" id="how">
             <div className="prose dark:prose-invert mx-auto max-w-6xl p-4 lg:max-w-6xl lg:p-8 xl:p-12">
                 <h2 className="text-center">
-                    Publish your digital garden with Flowershow
+                    Publish your notes with Obsidian Flowershow plugin
                 </h2>
                 <p className="text-center">🚧 Coming soon! 🚧</p>
-                <p>
-                    We are actively trialling Flowershow before wide release. If you'd
-                    like to help us test or be first on the list to use it please sign up
-                    using the form at the top of this page.
-                </p>
                 <div className="grid grid-cols-1 md:grid-cols-2 md:gap-8 gap-4 lg:gap-12">
-                    {/* 1. markdown folder */}
                     <div className="relative">
                         <div className="flex items-center space-x-4 sm:space-x-8">
                             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-sky-200 bg-sky-100 text-xl text-sky-600 ring-2 ring-white dark:border-sky-900 dark:bg-[#163C57] dark:text-sky-500 dark:ring-gray-950">
                                 1
                             </div>
                             <h3 className="m-0">
-                                You have your digital garden and you want to publish it...
+                                You have your Obsidian vault and you want to publish it.
                             </h3>
                         </div>
-                        <p>It can also be your Obsidian vault!</p>
+                        <p>If you haven't created your digital garden with Obsidian, but it's written in Markdown, you can still publish it with Flowershow Obsidian Plugin. Just open your digital garden in Obsidian and follow the steps below!</p>
                     </div>
                     <img
-                        src="/images/content_folder.png"
+                        src="/images/obsidian_vault.png"
                         alt=""
                         className="lg:max-h-[20rem] m-0 lg:my-6"
                     />
-                    {/* 2. npx flowershow publish */}
+
                     <div className="relative">
                         <div className="flex items-center space-x-4 sm:space-x-8">
                             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-sky-200 bg-sky-100 text-xl text-sky-600 ring-2 ring-white dark:border-sky-900 dark:bg-[#163C57] dark:text-sky-500 dark:ring-gray-950">
                                 2
                             </div>
                             <h3 className="m-0">
-                                ...so you publish it with the help of our command line tool...
+                                Create a Flowershow account and get your API key.
                             </h3>
                         </div>
                     </div>
                     <img
-                        src="/images/npx_publish.png"
+                        src="#"
                         alt=""
                         className="lg:max-h-[20rem] m-0 lg:my-6"
                     />
-                    {/* 3. published result */}
+
                     <div className="relative">
                         <div className="flex items-center space-x-4 sm:space-x-8">
                             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-sky-200 bg-sky-100 text-xl text-sky-600 ring-2 ring-white dark:border-sky-900 dark:bg-[#163C57] dark:text-sky-500 dark:ring-gray-950">
                                 3
                             </div>
-                            <h3 className="m-0">... and see your website online! 🎊</h3>
+                            <h3 className="m-0">Install Obsidian Flowershow plugin.</h3>
                         </div>
+                        <p>Then, configure it with your Flowershow account.</p>
                     </div>
                     <img
-                        src="/images/result_mac_dark.png"
+                        src="/images/plugin_install.png"
+                        alt=""
+                        className="lg:max-h-[20rem] m-0 lg:my-6"
+                    />
+
+                    <div className="relative">
+                        <div className="flex items-center space-x-4 sm:space-x-8">
+                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-sky-200 bg-sky-100 text-xl text-sky-600 ring-2 ring-white dark:border-sky-900 dark:bg-[#163C57] dark:text-sky-500 dark:ring-gray-950">
+                                4
+                            </div>
+                            <h3 className="m-0">
+                                Open the Flowershow Publish Status panel and publish your notes!
+                            </h3>
+                        </div>
+                        <p>You can also use Flowershow commands from Obsidian command pallete to publish all or a single note.</p>
+                    </div>
+                    <img
+                        src="/images/publish_status.png"
+                        alt=""
+                        className="lg:max-h-[20rem] m-0 lg:my-6"
+                    />
+
+                    <div className="relative">
+                        <div className="flex items-center space-x-4 sm:space-x-8">
+                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-sky-200 bg-sky-100 text-xl text-sky-600 ring-2 ring-white dark:border-sky-900 dark:bg-[#163C57] dark:text-sky-500 dark:ring-gray-950">
+                                5
+                            </div>
+                            <h3 className="m-0">
+                                Your digital garden is now live! 🎉
+                            </h3>
+                        </div>
+                        <p>And now, you can add or modify your notes, and share them with the world!</p>
+                    </div>
+                    <img
+                        src="/images/result_cloud.png"
                         alt=""
                         className="lg:max-h-[20rem] m-0 lg:my-6"
                     />

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import Typed from "typed.js";
+import { ArrowNarrowRightIcon } from '@heroicons/react/solid'
 
 /* eslint jsx-a11y/label-has-associated-control: off */
 export default function Hero() {
@@ -30,6 +31,15 @@ export default function Hero() {
             <div className="py-16 sm:px-2 lg:relative lg:py-20 lg:px-0">
                 <div className="mx-auto grid max-w-2xl grid-cols-1 items-center gap-y-16 gap-x-8 px-4 lg:max-w-8xl lg:grid-cols-2 lg:px-8 xl:gap-x-16 xl:px-12">
                     <div className="relative mb-10 lg:mb-0 md:text-center lg:text-left">
+                        <div className="mt-24 sm:mt-32 lg:mt-16 mb-12">
+                            <a href="https://github.com/datopian/obsidian-flowershow" className="inline-flex space-x-6 ">
+                                <span className="inline-flex items-center space-x-2 px-3 py-1 text-sm leading-6 text-accent rounded-full dark:bg-slate-500/10 ring-1 ring-inset ring-slate-400/50 dark:ring-slate-500/20">
+                                    <span>Just shipped:</span>
+                                    <span className="font-medium"> Obsidian Flowershow plugin v1.0 🚀</span>
+                                    <ArrowNarrowRightIcon className="h-5 w-5 text-gray-500" aria-hidden="true" />
+                                </span>
+                            </a>
+                        </div>
                         <div role="heading" className="h-44 md:h-32 lg:h-44 xl:h-32">
                             <h1 className="inline bg-gradient-to-r from-indigo-200 via-sky-400 to-indigo-200 bg-clip-text text-6xl tracking-tight text-transparent">
                                 Publish your

--- a/components/SelfPublishSteps.tsx
+++ b/components/SelfPublishSteps.tsx
@@ -5,77 +5,97 @@ export default function SelfPublishSteps() {
         <div id="self-publish" className="py-10 sm:px-2 lg:relative lg:px-0">
             <div className="rounded-md prose dark:prose-invert mx-auto max-w-6xl p-4 lg:max-w-6xl lg:p-8 xl:p-12">
                 <h2 className="text-center">
-                    Self-publish your digital garden with Flowershow
+                    Self-publish your digital garden with Obsidian Flowershow plugin
                 </h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 md:gap-8 gap-4 lg:gap-12">
-                    {/* 1. markdown folder */}
+
                     <div className="relative">
                         <div className="flex items-center space-x-4 sm:space-x-8">
-                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-fuchsia-200 bg-fuchsia-100 text-xl text-fuchsia-600 ring-2 ring-white dark:border-fuchsia-900 dark:bg-[#561b5e] dark:text-fuchsia-400 dark:ring-fuchsia-100">
+                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-fuchsia-200 bg-fuchsia-100 text-xl text-fuchsia-600 dark:border-fuchsia-900 dark:bg-[#561b5e] dark:text-fuchsia-400">
                                 1
                             </div>
                             <h3 className="m-0">
-                                You have your digital garden and you want to publish it...
+                                You have your Obsidian vault and you want to publish it.
                             </h3>
                         </div>
-                        <p>It can also be your Obsidian vault!</p>
+                        <p>If you haven't created your digital garden with Obsidian, but it's written in Markdown, you can still publish it with Flowershow Obsidian Plugin.
+                            Just open your digital garden in Obsidian and follow the steps below!
+                        </p>
                     </div>
                     <img
-                        src="/images/content_folder.png"
+                        src="/images/obsidian_vault.png"
                         alt=""
                         className="lg:max-h-[20rem] m-0 lg:my-6"
                     />
-                    {/* 2. npx flowershow generate */}
+
                     <div className="relative">
                         <div className="flex items-center space-x-4 sm:space-x-8">
-                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-fuchsia-200 bg-fuchsia-100 text-xl text-fuchsia-600 ring-2 ring-white dark:border-fuchsia-900 dark:bg-[#561b5e] dark:text-fuchsia-400 dark:ring-fuchsia-100">
+                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-fuchsia-200 bg-fuchsia-100 text-xl text-fuchsia-600 dark:border-fuchsia-900 dark:bg-[#561b5e] dark:text-fuchsia-400">
                                 2
                             </div>
-                            <h3 className="m-0">...so you install Flowershow...</h3>
+                            <h3 className="m-0">Copy Flowershow template repository to your GitHub account and deploy it.</h3>
                         </div>
+                        <p>Use <a href="https://github.com/datopian/flowershow#quick-clone-and-deploy">this "Deploy" button</a> to copy and deploy the repo automatically with Vercel.</p>
                     </div>
                     <img
-                        src="/images/npx_install.png"
+                        src="/images/vercel_deploy.png"
                         alt=""
                         className="lg:max-h-[20rem] m-0 lg:my-6"
                     />
-                    {/* 3. building */}
+
                     <div className="relative">
                         <div className="flex items-center space-x-4 sm:space-x-8">
-                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-fuchsia-200 bg-fuchsia-100 text-xl text-fuchsia-600 ring-2 ring-white dark:border-fuchsia-900 dark:bg-[#561b5e] dark:text-fuchsia-400 dark:ring-fuchsia-100">
+                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-fuchsia-200 bg-fuchsia-100 text-xl text-fuchsia-600 dark:border-fuchsia-900 dark:bg-[#561b5e] dark:text-fuchsia-400">
                                 3
                             </div>
-                            <h3 className="m-0">...and build your own beautiful website.</h3>
+                            <h3 className="m-0">Install Obsidian Flowershow plugin.</h3>
                         </div>
-                        <p>If you don't need a static build, run `npx flowershow build`.</p>
+                        <p>Then, configure it, so that it has access to your Flowershow repository.</p>
                     </div>
                     <img
-                        src="/images/npx_export.png"
+                        src="/images/plugin_install.png"
                         alt=""
                         className="lg:max-h-[20rem] m-0 lg:my-6"
                     />
-                    {/* 4. self hosting */}
+
                     <div className="relative">
                         <div className="flex items-center space-x-4 sm:space-x-8">
-                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-fuchsia-200 bg-fuchsia-100 text-xl text-fuchsia-600 ring-2 ring-white dark:border-fuchsia-900 dark:bg-[#561b5e] dark:text-fuchsia-400 dark:ring-fuchsia-100">
+                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-fuchsia-200 bg-fuchsia-100 text-xl text-fuchsia-600 dark:border-fuchsia-900 dark:bg-[#561b5e] dark:text-fuchsia-400">
                                 4
                             </div>
                             <h3 className="m-0">
-                                🎊 You can now self-publish on your favourite hosting platform!
+                                Open the Flowershow Publish Status panel and publish your notes!
                             </h3>
                         </div>
-                        <p>...like Netlify, GitHub Pages or Cloudflare.</p>
+                        <p>You can also use Flowershow commands from Obsidian command pallete to publish all or a single note.</p>
                     </div>
                     <img
-                        src="/images/netlify_deploy.png"
+                        src="/images/publish_status.png"
+                        alt=""
+                        className="m-0 rounded-md lg:my-6"
+                    />
+
+                    <div className="relative">
+                        <div className="flex items-center space-x-4 sm:space-x-8">
+                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-fuchsia-200 bg-fuchsia-100 text-xl text-fuchsia-600 dark:border-fuchsia-900 dark:bg-[#561b5e] dark:text-fuchsia-400">
+                                5
+                            </div>
+                            <h3 className="m-0">
+                                Your digital garden is now live! 🎉
+                            </h3>
+                        </div>
+                        <p>And now, you can add or modify your notes, and share them with the world!</p>
+                    </div>
+                    <img
+                        src="/images/result.png"
                         alt=""
                         className="m-0 rounded-md lg:my-6"
                     />
                 </div>
                 <div className="text-center mt-12 text-lg">
-                    👉 See our <a href="/docs/publish-tutorial">self-publish tutorial to learn more</a>!
+                    👉 See our <a href="/docs/publish-howto">self-publish howto to learn more</a>!
                 </div>
             </div>
-        </div>
+        </div >
     );
 }

--- a/content/docs/custom-theme.md
+++ b/content/docs/custom-theme.md
@@ -19,7 +19,7 @@ To this:
 
 Flowershow uses [Tailwind CSS](https://tailwindcss.com/) to style its websites, thus customization of fonts and colors is going to be done via tailwindcss through the use of its config file.
 
-The config file is called `tailwind.config.js` and located in the directory where your Flowershow app is installed, usually a `.flowershow` subfolder wherever you ran `npx flowershow install`.
+The config file is called `tailwind.config.js` and located in the root of your Flowershow app.
 
 > If you want to change the theme of only one section, then that should be done using HTML/Tailwindcss inside that specific markdown file
 

--- a/content/docs/embedding-files.md
+++ b/content/docs/embedding-files.md
@@ -23,9 +23,6 @@ cd my-flowershow-app/public
 ln -s your-content-dir/assets assets
 ```
 
-> [!note]
-> If you're using Flowershow CLI to create your Flowershow project, you don't need to manually create the symlink to your assets folder inside the /public folder. The CLI will allow you to select a subfolder in your content folder that it should treat as your assets folder, and it will create the symlink for you.
-
 3. Once linked, you can now use your assets folder as a source. For example:
 
 ```md

--- a/content/docs/excalidraw.md
+++ b/content/docs/excalidraw.md
@@ -45,7 +45,6 @@ For example, assuming your Obsidian vault is your Flowershow content folder you'
 
 ```bash
 $ cd <flowershow-template-directory>
-# .flowershow folder created by `npx flowershow@latest install`, e.g. ~/.flowershow
 $ ln -s <relative-path-to-excalidraw-folder> ./public/excalidraw
 # e.g. ln -s ../my-digital-garden/excalidraw ./public/excalidraw
 ```

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -12,7 +12,7 @@ Flowershow supports **CommonMark** and **GitHub Flavored Markdown**, but also ma
 
 ## Tutorials
 
-1. [[publish-tutorial|How to (self) publish your markdown files with Flowershow]]
+1. [[publish-howto|How to (self) publish your markdown files with Flowershow Obsidian plugin]]
 2. [[custom-theme|Customize theme]]
 3. [[2023-02-16-nextjs-tutorial|Jumpstart a NextJS site with Flowershow]]
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,45 +11,55 @@ import type { CustomAppProps } from "./_app";
 type HomePageProps = CustomAppProps;
 
 export default function Home() {
-  return (
-    <main>
-      <Hero />
-      <WhatIsFlowershow />
+    return (
+        <main>
+            <Hero />
+            <WhatIsFlowershow />
 
-      {/** Tutorial video **/}
-      {/* <div className="mx-auto lg:max-w-3xl">https://www.youtube.com/watch?v=HxD6NWYCea0</div> */}
+            <div className="py-10 sm:px-2 lg:relative lg:px-0" id="overview">
+                <div className="prose dark:prose-invert mx-auto max-w-6xl px-4 lg:max-w-6xl lg:px-8 xl:px-12">
+                    <h2 className="text-center">🚀 Now available as Obsidian plugin! 🚀</h2>
+                    <p>
+                        Flowershow is now available as an Obsidian plugin! This means you can now
+                        publish your digital garden directly from Obsidian, in just a few easy steps, without having to use the command line at all!
+                        <p>👉 See our <a href="/docs/publish-howto">self-publish howto</a> to get started.</p>
+                        PS: It's so good, the Flowershow CLI has been deprecated and will no longer be maintained 😎
+                        <p>🚧 TBD: Support for configuring Flowershow from the Obsidian settings UI.</p>
+                    </p>
+                </div>
+            </div>
 
-      <SelfPublishSteps />
-      <CloudPublishSteps />
-      <Features />
 
-      {/** Why the name? **/}
-      <div className="py-10 sm:px-2 lg:relative lg:px-0">
-        <div className="prose dark:prose-invert mx-auto max-w-2xl px-4 lg:max-w-4xl lg:px-8 xl:px-12">
-          <h2 className="text-center">Why the name?</h2>
-          <p>
-            Flowershow is about sharing your digital garden -- putting it "on
-            show" to the world. And what do you have in your garden? Flowers!
-            Hence "Flowershow": it shows off your digital garden to the world!
-          </p>
-        </div>
-      </div>
-    </main>
-  );
+            <SelfPublishSteps />
+            <CloudPublishSteps />
+            <Features />
+            {/** Why the name? **/}
+            <div className="py-10 sm:px-2 lg:relative lg:px-0">
+                <div className="prose dark:prose-invert mx-auto max-w-2xl px-4 lg:max-w-4xl lg:px-8 xl:px-12">
+                    <h2 className="text-center">Why the name?</h2>
+                    <p>
+                        Flowershow is about sharing your digital garden -- putting it "on
+                        show" to the world. And what do you have in your garden? Flowers!
+                        Hence "Flowershow": it shows off your digital garden to the world!
+                    </p>
+                </div>
+            </div>
+        </main>
+    );
 }
 
 export const getStaticProps: GetStaticProps = async (): Promise<
-  GetStaticPropsResult<HomePageProps>
+    GetStaticPropsResult<HomePageProps>
 > => {
-  return {
-    props: {
-      meta: {
-        urlPath: "/",
-        showToc: false,
-        showEditLink: false,
-        showSidebar: false,
-        showComments: false,
-      },
-    },
-  };
+    return {
+        props: {
+            meta: {
+                urlPath: "/",
+                showToc: false,
+                showEditLink: false,
+                showSidebar: false,
+                showComments: false,
+            },
+        },
+    };
 };

--- a/public/images/content_folder.png
+++ b/public/images/content_folder.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fbedfda6530f0dca62cc7563b316cc1de9d37c3066a47c07ab74c7fbd7efda10
-size 20465

--- a/public/images/npx_install.png
+++ b/public/images/npx_install.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c7663d338f41c1f6aedcf2bd98be43281a6101665eb283f681719c8dbde456a1
-size 67631

--- a/public/images/obsidian_vault.png
+++ b/public/images/obsidian_vault.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:496c4e814d93b08057ef265a51297b0f2a5bbe34b8e7ff602ebcab95bc823ed3
+size 303061

--- a/public/images/plugin_install.png
+++ b/public/images/plugin_install.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:665902215dcbdead5c8cc3a0a271ca7b0019afa50ecae1a0cb37d514b0e1a78b
+size 546777

--- a/public/images/plugin_settings.png
+++ b/public/images/plugin_settings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21da499d4701d2f706977973c351739caa2bead1e07f7c2c53914a68086fbec0
+size 408478

--- a/public/images/publish_status.png
+++ b/public/images/publish_status.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d24cf022c98042b7b65d08f55f03ad7769086694cf9a72e0b2ae604d33c53a3f
+size 280588

--- a/public/images/result.png
+++ b/public/images/result.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dd19593b1e518d02fe54c374a2647105ff3a7bcf7fef7b87f90823151d20ab3
+size 321534

--- a/public/images/result_cloud.png
+++ b/public/images/result_cloud.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc92127f90d593edff622fe6789806f33b52af05bd128575b21247ba1ce4aa73
+size 314889

--- a/public/images/vercel_deploy.png
+++ b/public/images/vercel_deploy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9d4812b5d7abd025a39b3aa698c43185723ebfc7e3c9ee665f74013b3593375
+size 388874

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -36,6 +36,10 @@ module.exports = {
           DEFAULT: colors.sky[400],
           dark: colors.sky[400],
         },
+        accent: {
+          DEFAULT: colors.amber[300],
+          dark: colors.amber[300],
+        },
       },
     },
   },


### PR DESCRIPTION
Closes #3 

## Summary

- Obsidian plugin announcement in Flowershow home page hero:
<img width="1470" alt="image" src="https://github.com/datopian/flowershow-app/assets/52197250/03eefd35-20a9-42c0-96a4-fed9bc8d5982">

- Obsidian plugin announcement in the new section:
<img width="1470" alt="image" src="https://github.com/datopian/flowershow-app/assets/52197250/dc5fe9a0-9e9b-41fd-ae71-0b0584402d70">

- Self-publish overview updated:
<img width="1470" alt="image" src="https://github.com/datopian/flowershow-app/assets/52197250/e4555836-0719-4b68-be1d-49e97c46fcba">

- Cloud-publish overview updated:
<img width="1470" alt="image" src="https://github.com/datopian/flowershow-app/assets/52197250/531554bf-5cde-43bb-b06d-81fd20898572">

- Any references to Flowershow CLI removed from docs pages
